### PR TITLE
Alpine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,41 @@
-.PHONY: arm64 x86_64 emacs-native push manifests
+.PHONY: docker arm64 amd64 build push latest
 
-# To publish images, build arm on an M1, build amd on an ec2
-# instance. Push the tagged images to dockerhub. Then on either host,
-# pull down all the images, for every arch. From there, create and
-# then push the manifest.
-#
-# i.e.
-# on an arm host
-# % make push
-# now on an amd host
-# $ make push manifests
+# make docker  - creates Dockerfile in emacs-native/
+# make arm64   - builds local arm64 image
+# make amd64   - builds local amd64 image
+# make build   - builds both images, tags this host's arch as emacs-native:latest (then: docker run emacs-native)
+# make push    - pushes both images and creates a single multi-arch manifest on Docker Hub
+# make latest  - tags the Docker Hub manifest as :latest
 
-EMACS_BRANCH=30.2
-FP=v${EMACS_BRANCH}-$(shell printf '%04d' $(shell git rev-list --count --no-merges HEAD))-$(shell git rev-parse --short HEAD)
+EMACS_BRANCH ?= 30.2
+FP = v$(EMACS_BRANCH)-$(shell printf '%04d' $(shell git rev-list --count --no-merges HEAD))-$(shell git rev-parse --short HEAD)
+DOCKERFILE = emacs-native/Dockerfile
+CONTEXT = emacs-native
+ARCH = $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 
-emacs-native: arm64 x86_64
+build: arm64 amd64
+	docker tag emacs-native:$(FP)-$(ARCH) emacs-native:latest
 
-arm64 x86_64:
-	ARCH=$@ ./build/build.sh all
-	docker tag emacs-native:${FP}-$@ wwarner/emacs-native:${FP}-$@
+docker:
+	./build/build.sh all
 
-push: emacs-native
-	docker push wwarner/emacs-native:${FP}-arm64
-	docker push wwarner/emacs-native:${FP}-x86_64
+arm64 amd64: docker
+	BUILDKIT_PROGRESS=plain docker build --platform linux/$@ \
+		-t emacs-native:$(FP)-$@ \
+		-f $(DOCKERFILE) $(CONTEXT)
+	docker tag emacs-native:$(FP)-$@ wwarner/emacs-native:$(FP)-$@
 
-manifests: push
-	docker pull wwarner/emacs-native:${FP}-arm64
-	docker pull wwarner/emacs-native:${FP}-x86_64
-	docker manifest create wwarner/emacs-native:${FP} \
-	       --amend wwarner/emacs-native:${FP}-arm64 \
-               --amend wwarner/emacs-native:${FP}-x86_64
-	docker manifest push wwarner/emacs-native:${FP}
+push: build
+	docker push wwarner/emacs-native:$(FP)-arm64
+	docker push wwarner/emacs-native:$(FP)-amd64
+	docker manifest create wwarner/emacs-native:$(FP) \
+		--amend wwarner/emacs-native:$(FP)-arm64 \
+		--amend wwarner/emacs-native:$(FP)-amd64
+	docker manifest push wwarner/emacs-native:$(FP)
 
-latest: manifests
-	docker manifest rm wwarner/emacs-native:latest
+latest: push
+	-docker manifest rm wwarner/emacs-native:latest
 	docker manifest create wwarner/emacs-native:latest \
-	       --amend wwarner/emacs-native:${FP}-arm64 \
-               --amend wwarner/emacs-native:${FP}-x86_64
+		--amend wwarner/emacs-native:$(FP)-arm64 \
+		--amend wwarner/emacs-native:$(FP)-amd64
 	docker manifest push wwarner/emacs-native:latest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Dockerfiles for Emacs With Native Compilation
 =============================================
 
-Native Compilation, 24 bit color, LSP, Eglot, Gopls, Pyright, Ripgrep,
+Native Compilation, 24 bit color, LSP, Eglot, Gptel, Gopls, Pyright, Ripgrep,
 Fzf, Treemacs, HideShow and more. Eliminates trial and error. Runs the
 same everywhere!
 
@@ -36,19 +36,53 @@ Or build it locally
 
 Emacs lisp can be compiled to native machine code when built
 `--with-native-compilation` enabled, resulting in a perceptible
-performance improvement. There are several OS level dependencides
-required by native compilation that are captured in this Dockerfile,
-including libgccjit and gnutls.
+performance improvement. This image is based on alpine's
+emacs-x11-nativecomp for that reason.
 
-## Native JSON with libjansson
+## Modes
 
-Native json support is also supported by enabling `--with-json` and
-its libjansson dependencies.
+* ai
 
-## LSPs
+`gptel`, `mcp-hub`, and a couple of mcps installed.
 
-Each language has it's own procedure for installing its lsp, captured
-in `modes/{{lang}}/Docker.part`.
+* cpp
+
+`clangd` and `bear`
+
+* go
+
+`go` toolchain, `dlv`, `gopls` and `gofumpt`
+
+* js
+
+`typescript-language-server`, `typescript`, `prettier` installed and
+configured for js, ts & json
+
+* lua
+
+`lua-language-server`
+
+* py
+
+`pyright`
+
+* sh
+
+`bash-language-server`
+
+* sql
+
+`shandy-sqlfmt`, `sqlfluff`
+
+* yml
+
+`yaml-language-server`, `helm_ls`, `indent-tools-minor-mode`, also `yaml-ts-mode`
+
+## Treesit
+
+Treesitter grammars for yaml, javascript, json, typescript and tsx are
+installed. Locations for many other languages are captured, so that
+`treesit-install-grammar` works without fuss.
 
 ## No X11
 
@@ -56,9 +90,8 @@ I have been running emacs without windows for several years now
 because it's so fast and portable. In particular, when working with a
 lot of data, I find that I need to run emacs on a server in the
 cloud. Somewhere along the line, I realized that emacs is a lot more
-fun without graphics. The compilation step in this build is also much
-much faster `--without-x11`. If you want your graphics back, then just
-drop that configuration flag.
+fun without graphics. If you want your graphics back, you can try
+running build/emacs-x11.sh.
 
 ## 24bit Color & Unicode
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -9,25 +9,18 @@ then
     exit 1
 fi
 
-DOCKER_TAG_SUFF=""
 MODES_AVAILABLE=($(ls modes))
 MODES=("${MODES_AVAILABLE[@]}")
 
 if [ "$1" != "all" ]
 then
     MODES=("$@")
-    DOCKER_TAG_SUFF=-$(printf '%s-' "${MODES[@]}") # join args
-    DOCKER_TAG_SUFF=${DOCKER_TAG_SUFF%-} # Remove trailing dash
-    DOCKER_TAG_SUFF=$(echo "$DOCKER_TAG_SUFF" | tr '/_' '-' | tr '[:upper:]' '[:lower:]')
 fi
-DOCKER_TAG="emacs-native${DOCKER_TAG_SUFF}"
 
 set -eu -o pipefail
 
 EMACS_BRANCH="${EMACS_BRANCH:=30.2}"
-FP=v"${EMACS_BRANCH}"-"$(printf '%04d' "$(git rev-list --count --no-merges HEAD)")"-"$(git rev-parse --short HEAD)"
-BASE=${FP}-${ARCH}
-DOCKERFILE=".Dockerfile-${DOCKER_TAG}"
+DOCKERFILE="Dockerfile"
 
 # Top
 cat > "$DOCKERFILE" <<EOF
@@ -87,15 +80,3 @@ RUN emacs -Q --script ".emacs.d/init.el"
 
 CMD ["emacs"]
 EOF
-
-BUILDKIT_PROGRESS=plain docker build --platform "linux/${ARCH}" -t "${DOCKER_TAG}:${BASE}" -f "${DOCKERFILE}" .
-echo "sample invocation:"
-cat<<_EOF
-  docker run -it --rm \\
-    --name "${DOCKER_TAG}" \\
-    -v\$HOME/src:/root/src \\
-    -v\$HOME/.gitconfig:/etc/gitconfig \\
-    -v\$HOME/.ssh:/root/.ssh \\
-    -v\$HOME/.aws:/root/.aws \\
-    "${DOCKER_TAG}"
-_EOF

--- a/build/build.sh
+++ b/build/build.sh
@@ -34,29 +34,26 @@ cat > "$DOCKERFILE" <<EOF
 # Copyright 2024 William Warner
 # SPDX-License-Identifier: GPL-3.0-only
 # file generated with build.sh $@
-FROM debian:trixie-slim
+FROM alpine:3.23
 ARG EMACS_BRANCH
 
-COPY debian-backports.sources /etc/apt/sources.list.d/debian-backports.sources
-
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update -t trixie-backports -y && \
-    apt-get install -t trixie-backports -y \
-    apt-transport-https \
+RUN apk add --no-cache \
     autoconf \
-    build-essential \
+    bash \
+    build-base \
     ca-certificates \
     cmake \
     curl \
-    emacs-nox \
+    emacs-x11-nativecomp \
+    emacs-vterm \
     fzf \
-    gcc-12 \
     git \
     libvterm-dev \
+    ncurses \
+    openssh-client \
     ripgrep \
     w3m \
-    wget \
-    && rm -rf /var/lib/apt/lists/*
+    wget
 
 WORKDIR /root
 

--- a/build/emacs-x11.sh
+++ b/build/emacs-x11.sh
@@ -1,0 +1,5 @@
+xhost +localhost
+docker run --rm --name emacs-x11 -e DISPLAY=host.docker.internal:0 \
+       -v$PWD:/src -v$HOME/.ssh:/root/.ssh -v$HOME/src:/root/src \
+       -v$HOME/.aws:/root/.aws -v$HOME/.gitconfig:/etc/gitconfig \
+       -it wwarner/emacs-native:latest

--- a/emacs-native/modes/ai/Dockerfile.part
+++ b/emacs-native/modes/ai/Dockerfile.part
@@ -1,11 +1,7 @@
 # Copyright 2024 William Warner
 # SPDX-License-Identifier: GPL-3.0-only
-ENV DEBIAN_FRONTEND=noninteractive
-RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
-RUN apt-get update && \
-    apt-get install -y \
-    nodejs && \
-    rm -rf /var/lib/apt/lists/*
+
+RUN apk add --no-cache nodejs npm
 # the `fetch` mcp is installed with uvx
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH

--- a/emacs-native/modes/cpp/Dockerfile.part
+++ b/emacs-native/modes/cpp/Dockerfile.part
@@ -1,8 +1,5 @@
 # Copyright 2024 William Warner
 # SPDX-License-Identifier: GPL-3.0-only
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && \
-    apt-get install -y \
-    clangd \
-    bear && \
-    rm -rf /var/lib/apt/lists/*
+
+# clangd is provided by clang21-extra-tools (no standalone clangd package on Alpine)
+RUN apk add --no-cache clang21-extra-tools bear

--- a/emacs-native/modes/go/Dockerfile.part
+++ b/emacs-native/modes/go/Dockerfile.part
@@ -1,8 +1,7 @@
 # Copyright 2024 William Warner
 # SPDX-License-Identifier: GPL-3.0-only
-ENV DEBIAN_FRONTEND=noninteractive
 
-COPY --from=golang:1.25.3-trixie /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.26-alpine /usr/local/go/ /usr/local/go/
 ENV PATH=/root/go/bin:/usr/local/go/bin:$PATH
 
 RUN go install github.com/go-delve/delve/cmd/dlv@latest

--- a/emacs-native/modes/js/Dockerfile.part
+++ b/emacs-native/modes/js/Dockerfile.part
@@ -1,11 +1,7 @@
 # Copyright 2024 William Warner
 # SPDX-License-Identifier: GPL-3.0-only
-ENV DEBIAN_FRONTEND=noninteractive
-RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
-RUN apt-get update && \
-    apt-get install -y \
-    nodejs && \
-    rm -rf /var/lib/apt/lists/*
+
+RUN apk add --no-cache nodejs npm
 
 # Install TypeScript language server and Prettier for formatting
 RUN npm install -g typescript-language-server typescript prettier

--- a/emacs-native/modes/lua/Dockerfile.part
+++ b/emacs-native/modes/lua/Dockerfile.part
@@ -1,10 +1,17 @@
 # Copyright 2024 William Warner
 # SPDX-License-Identifier: GPL-3.0-only
 
-RUN mkdir -p /usr/local/lua-language-server-3.15.0 && \
-    cd /usr/local/lua-language-server-3.15.0 && \
-    curl -s -L https://github.com/LuaLS/lua-language-server/releases/download/3.15.0/lua-language-server-3.15.0-linux-arm64.tar.gz | \
-    tar xvzf - && \
-    ln -s $PWD/bin/lua-language-server /usr/local/bin
+ARG LUA_LS_VERSION=3.15.0
+RUN set -eux; \
+    ARCH=$(uname -m); \
+    case "${ARCH}" in \
+        x86_64) LUA_ARCH=x64 ;; \
+        aarch64) LUA_ARCH=arm64 ;; \
+        *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;; \
+    esac; \
+    mkdir -p /usr/local/lua-language-server-${LUA_LS_VERSION}; \
+    cd /usr/local/lua-language-server-${LUA_LS_VERSION}; \
+    curl -s -L "https://github.com/LuaLS/lua-language-server/releases/download/${LUA_LS_VERSION}/lua-language-server-${LUA_LS_VERSION}-linux-${LUA_ARCH}.tar.gz" | tar xvzf -; \
+    ln -sf /usr/local/lua-language-server-${LUA_LS_VERSION}/bin/lua-language-server /usr/local/bin/lua-language-server
 
 COPY modes/lua/.emacs.d .emacs.d

--- a/emacs-native/modes/py/Dockerfile.part
+++ b/emacs-native/modes/py/Dockerfile.part
@@ -1,15 +1,7 @@
 # Copyright 2024 William Warner
 # SPDX-License-Identifier: GPL-3.0-only
-ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get install -y \
-    python3 \
-    python3-dev \
-    python3-pip \
-    python3-venv \
-    python3-launchpadlib && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache python3 python3-dev py3-pip
 
 RUN python3 -m venv /root/.virtualenv
 ENV PATH="/root/.virtualenv/bin:$PATH"

--- a/emacs-native/modes/sh/Dockerfile.part
+++ b/emacs-native/modes/sh/Dockerfile.part
@@ -1,14 +1,7 @@
 # Copyright 2024 William Warner
 # SPDX-License-Identifier: GPL-3.0-only
 
-RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && \
-    apt-get install -y \
-    nodejs \
-    shellcheck \
-    shfmt && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache nodejs npm shellcheck shfmt
 RUN npm i -g bash-language-server
 
 COPY modes/sh/.emacs.d .emacs.d

--- a/emacs-native/modes/sql/Dockerfile.part
+++ b/emacs-native/modes/sql/Dockerfile.part
@@ -1,15 +1,7 @@
 # Copyright 2024 William Warner
 # SPDX-License-Identifier: GPL-3.0-only
-ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get install -y \
-    python3 \
-    python3-dev \
-    python3-pip \
-    python3-venv \
-    python3-launchpadlib && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache python3 python3-dev py3-pip
 
 RUN python3 -m venv /root/.virtualenv
 ENV PATH="/root/.virtualenv/bin:$PATH"

--- a/emacs-native/modes/yml/Dockerfile.part
+++ b/emacs-native/modes/yml/Dockerfile.part
@@ -1,11 +1,7 @@
 # Copyright 2024 William Warner
 # SPDX-License-Identifier: GPL-3.0-only
-ENV DEBIAN_FRONTEND=noninteractive
-RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
-RUN apt-get update && \
-    apt-get install -y \
-    nodejs && \
-    rm -rf /var/lib/apt/lists/*
+
+RUN apk add --no-cache nodejs npm
 
 RUN npm install --global yaml-language-server
 

--- a/examples/go/run.sh
+++ b/examples/go/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 # Copyright 2024 William Warner
 # SPDX-License-Identifier: BSD-3-Clause
 


### PR DESCRIPTION
The reason for trying alpine is that Go produces an image for alpine3.23, and alpine3.23 bundles emacs30.2. The latest emacs I can get from debian trixie is 30.1. I can build emacs myself, but it takes *forever* so, I thought it was worth trying alpine/musl. So far haven't seen any issues.